### PR TITLE
simplify graph

### DIFF
--- a/packages/larissa/src/GraphEdge.js
+++ b/packages/larissa/src/GraphEdge.js
@@ -1,0 +1,25 @@
+// @flow
+
+import type Input from './Input';
+import type Node from './Node';
+import type Output from './Output';
+
+export default class GraphEdge {
+    from: Node;
+    to: Node;
+    connections: Set<string>;
+
+    constructor(from: Node, to: Node) {
+        this.from = from;
+        this.to = to;
+        this.connections = new Set();
+    }
+
+    addConnection(output: Output, input: Input) {
+        const connectionId = output.id + ':' + input.id;
+        if (this.connections.has(connectionId)) {
+            throw new Error(`There is already a connection between ${output.id} and ${input.id}`);
+        }
+        this.connections.add(connectionId);
+    }
+}

--- a/packages/larissa/src/Pipeline.js
+++ b/packages/larissa/src/Pipeline.js
@@ -110,21 +110,6 @@ export default class Pipeline extends Node {
     }
 
     async _run() {
-        /*const self = this;
-        /*const endNodes: Array<Node> = Array.from(this.graph.sinks()).map(mapNode); // grab endNodes
-        const nodesToRun = endNodes.filter(node => node instanceof Node);
-        for (const node of endNodes) {
-            addParents(node);
-        }
-        function addParents(node) {
-            for (const [, parent] of self.graph.verticesTo(node.id)) {
-                if (parent instanceof Node) {
-                    if (nodesToRun.includes(parent)) nodesToRun.splice(nodesToRun.indexOf(parent), 1);
-                    nodesToRun.unshift(parent);
-                }
-                addParents(parent);
-            }
-        }*/
         const nodesToRun = Array.from(this.graph.transitiveReduction().vertices_topologically()).map(mapNode);
         await this.schedule(nodesToRun);
     }


### PR DESCRIPTION
Do not create vertices for ports. Instead, connect the nodes directly
and store their edges in a separate structure.